### PR TITLE
New contents algorithm with lower memory footprint

### DIFF
--- a/database/leveldb.go
+++ b/database/leveldb.go
@@ -50,6 +50,11 @@ func internalOpen(path string) (*leveldb.DB, error) {
 	o := &opt.Options{
 		Filter:                 filter.NewBloomFilter(10),
 		OpenFilesCacheCapacity: 256,
+
+		// reduce compacting of db
+		CompactionL0Trigger:    32,
+		WriteL0PauseTrigger:    96,
+		WriteL0SlowdownTrigger: 64,
 	}
 
 	return leveldb.OpenFile(path, o)

--- a/database/leveldb.go
+++ b/database/leveldb.go
@@ -128,7 +128,7 @@ func (l *levelDB) Delete(key []byte) error {
 	return l.db.Delete(key, nil)
 }
 
-// HasKeysByPrefix checks whether there is any k
+// KeysByPrefix returns all keys that start with prefix
 func (l *levelDB) KeysByPrefix(prefix []byte) [][]byte {
 	result := make([][]byte, 0, 20)
 

--- a/database/leveldb.go
+++ b/database/leveldb.go
@@ -21,6 +21,7 @@ type Storage interface {
 	Get(key []byte) ([]byte, error)
 	Put(key []byte, value []byte) error
 	Delete(key []byte) error
+	HasPrefix(prefix []byte) bool
 	KeysByPrefix(prefix []byte) [][]byte
 	FetchByPrefix(prefix []byte) [][]byte
 	Close() error
@@ -118,7 +119,7 @@ func (l *levelDB) Delete(key []byte) error {
 	return l.db.Delete(key, nil)
 }
 
-// KeysByPrefix returns all keys that start with prefix
+// HasKeysByPrefix checks whether there is any k
 func (l *levelDB) KeysByPrefix(prefix []byte) [][]byte {
 	result := make([][]byte, 0, 20)
 
@@ -133,6 +134,13 @@ func (l *levelDB) KeysByPrefix(prefix []byte) [][]byte {
 	}
 
 	return result
+}
+
+// HasPrefix checks whether it can find any key with given prefix and returns true if one exists
+func (l *levelDB) HasPrefix(prefix []byte) bool {
+	iterator := l.db.NewIterator(nil, nil)
+	defer iterator.Release()
+	return iterator.Seek(prefix) && bytes.HasPrefix(iterator.Key(), prefix)
 }
 
 // FetchByPrefix returns all values with keys that start with prefix

--- a/deb/contents.go
+++ b/deb/contents.go
@@ -32,6 +32,9 @@ func (index *ContentsIndex) Key(path string) []byte {
 func (index *ContentsIndex) Push(p *Package, packagePool aptly.PackagePool) error {
 	contents := p.Contents(packagePool)
 
+	index.db.StartBatch()
+	defer index.db.FinishBatch()
+
 	for _, path := range contents {
 		var value []byte
 		key := index.Key(path)

--- a/deb/contents.go
+++ b/deb/contents.go
@@ -62,23 +62,14 @@ func (index *ContentsIndex) WriteTo(w io.Writer) (int64, error) {
 		return n, err
 	}
 
-	keyPrefix := index.Key("")
-	keys := index.db.KeysByPrefix(keyPrefix)
-	for i := range keys {
-		key := keys[i]
-
-		value, err := index.db.Get(key)
-		if err != nil {
-			return n, err
-		}
+	prefix := index.Key("")
+	err = index.db.ProcessByPrefix(prefix, func(key []byte, value []byte) error {
 		parts := strings.Split(string(key), "$")
 		path := parts[len(parts)-1]
 		nn, err = fmt.Fprintf(w, "%s %s\n", path, string(value))
 		n += int64(nn)
-		if err != nil {
-			return n, err
-		}
-	}
+		return err
+	})
 
-	return n, nil
+	return n, err
 }

--- a/deb/contents.go
+++ b/deb/contents.go
@@ -49,7 +49,7 @@ func (index *ContentsIndex) Push(p *Package, packagePool aptly.PackagePool) {
 // Empty checks whether index contains no packages
 func (index *ContentsIndex) Empty() bool {
 	key := index.Key("")
-	return len(index.db.FetchByPrefix(key)) == 0
+	return !index.db.HasPrefix(key)
 }
 
 // WriteTo dumps sorted mapping of files to qualified package names

--- a/deb/contents.go
+++ b/deb/contents.go
@@ -63,7 +63,7 @@ func (index *ContentsIndex) Empty() bool {
 // WriteTo dumps sorted mapping of files to qualified package names
 func (index *ContentsIndex) WriteTo(w io.Writer) (int64, error) {
 	// For performance reasons push method wrote on key per path and package
-	// in this method we know need to merge all pkg with have the same path
+	// in this method we now need to merge all pkg with have the same path
 	// and write it to contents index file
 	var n int64
 

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -561,7 +561,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 						contentIndex := contentIndexes[key]
 
 						if contentIndex == nil {
-							contentIndex = NewContentsIndex()
+							contentIndex = NewContentsIndex(collectionFactory.db, *p, component, arch, pkg.IsUdeb)
 							contentIndexes[key] = contentIndex
 						}
 

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -565,7 +565,10 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 							contentIndexes[key] = contentIndex
 						}
 
-						contentIndex.Push(pkg, packagePool)
+						err = contentIndex.Push(pkg, packagePool)
+						if err != nil {
+							return err
+						}
 					}
 
 					bufWriter, err = indexes.PackageIndex(component, arch, pkg.IsUdeb).BufWriter()


### PR DESCRIPTION
Using leveldb to persist contents file paths on file system instead of keeping it in memory.

This way memory footprint decreases significantly. Trade-off a slight slower contents generation especially with large repositories such as Ubuntu.

This fixes issue #415

Also see upstream PR https://github.com/smira/aptly/pull/454