### PR TITLE
only create bzip file if needed

### DIFF
--- a/deb/index_files.go
+++ b/deb/index_files.go
@@ -62,7 +62,7 @@ func (file *indexFile) Finalize(signer utils.Signer) error {
 	}
 
 	if file.compressable {
-		err = utils.CompressFile(file.tempFile)
+		err = utils.CompressFile(file.tempFile, file.onlyGzip)
 		if err != nil {
 			file.tempFile.Close()
 			return fmt.Errorf("unable to compress index file: %s", err)

--- a/utils/compress.go
+++ b/utils/compress.go
@@ -11,7 +11,7 @@ import (
 //
 // It uses internal gzip and external bzip2, see:
 // https://code.google.com/p/go/issues/detail?id=4828
-func CompressFile(source *os.File) error {
+func CompressFile(source *os.File, onlyGzip bool) error {
 	gzPath := source.Name() + ".gz"
 	gzFile, err := os.Create(gzPath)
 	if err != nil {
@@ -24,7 +24,7 @@ func CompressFile(source *os.File) error {
 
 	source.Seek(0, 0)
 	_, err = io.Copy(gzWriter, source)
-	if err != nil {
+	if err != nil || onlyGzip {
 		return err
 	}
 

--- a/utils/compress_test.go
+++ b/utils/compress_test.go
@@ -27,7 +27,7 @@ func (s *CompressSuite) TearDownTest(c *C) {
 }
 
 func (s *CompressSuite) TestCompress(c *C) {
-	err := CompressFile(s.tempfile)
+	err := CompressFile(s.tempfile, false)
 	c.Assert(err, IsNil)
 
 	buf := make([]byte, len(testString))


### PR DESCRIPTION
Creating bzip of contents files is not necessary but might use up the last memory available.

See also upstream PR https://github.com/smira/aptly/pull/449