### PR TITLE
Only lock API get requests till configured timeout occurs

### DIFF
--- a/api/graph.go
+++ b/api/graph.go
@@ -23,8 +23,8 @@ func apiGraph(c *gin.Context) {
 	factory := context.CollectionFactory()
 
 	// TODO there should be a timeout here
-	factory.RemoteRepoCollection().RLock()
-	defer factory.RemoteRepoCollection().RUnlock()
+	factory.RemoteRepoCollection().Lock()
+	defer factory.RemoteRepoCollection().Unlock()
 	factory.LocalRepoCollection().Lock()
 	defer factory.LocalRepoCollection().Unlock()
 	factory.SnapshotCollection().Lock()

--- a/api/graph.go
+++ b/api/graph.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"time"
+	"errors"
 )
 
 // GET /api/graph.:ext
@@ -35,7 +36,7 @@ func apiGraph(c *gin.Context) {
 		publishedRepoCollection,
 	)
 	if !ok {
-		c.Fail(500, fmt.Errorf("Unable to build graph. Other process is locking resources."))
+		c.Fail(500, errors.New("Unable to build graph. Other process is locking resources."))
 		return
 	}
 	defer remoteRepoCollection.Unlock()

--- a/api/graph.go
+++ b/api/graph.go
@@ -9,7 +9,6 @@ import (
 	"mime"
 	"os"
 	"os/exec"
-	"time"
 	"errors"
 )
 
@@ -29,7 +28,7 @@ func apiGraph(c *gin.Context) {
 	snapshotCollection := factory.SnapshotCollection()
 	publishedRepoCollection := factory.PublishedRepoCollection()
 	ok := deb.TryLockMutexes(
-		2 * time.Second,
+		readTimeout,
 		remoteRepoCollection,
 		localRepoCollection,
 		snapshotCollection,

--- a/api/graph.go
+++ b/api/graph.go
@@ -22,14 +22,15 @@ func apiGraph(c *gin.Context) {
 
 	factory := context.CollectionFactory()
 
+	// TODO there should be a timeout here
 	factory.RemoteRepoCollection().RLock()
 	defer factory.RemoteRepoCollection().RUnlock()
-	factory.LocalRepoCollection().RLock()
-	defer factory.LocalRepoCollection().RUnlock()
-	factory.SnapshotCollection().RLock()
-	defer factory.SnapshotCollection().RUnlock()
-	factory.PublishedRepoCollection().RLock()
-	defer factory.PublishedRepoCollection().RUnlock()
+	factory.LocalRepoCollection().Lock()
+	defer factory.LocalRepoCollection().Unlock()
+	factory.SnapshotCollection().Lock()
+	defer factory.SnapshotCollection().Unlock()
+	factory.PublishedRepoCollection().Lock()
+	defer factory.PublishedRepoCollection().Unlock()
 
 	graph, err := deb.BuildGraph(factory)
 	if err != nil {

--- a/api/publish.go
+++ b/api/publish.go
@@ -6,7 +6,6 @@ import (
 	"github.com/smira/aptly/deb"
 	"github.com/smira/aptly/utils"
 	"strings"
-	"time"
 	"errors"
 )
 
@@ -55,7 +54,7 @@ func apiPublishList(c *gin.Context) {
 	snapshotCollection := context.CollectionFactory().SnapshotCollection()
 	collection := context.CollectionFactory().PublishedRepoCollection()
 
-	ok := deb.TryLockMutexes(2 * time.Second, localCollection, snapshotCollection, collection)
+	ok := deb.TryLockMutexes(readTimeout, localCollection, snapshotCollection, collection)
 	if !ok {
 		c.Fail(500, errors.New("Unable get published collections. Other process is locking resources"))
 		return

--- a/api/publish.go
+++ b/api/publish.go
@@ -49,17 +49,18 @@ func parseEscapedPath(path string) string {
 
 // GET /publish
 func apiPublishList(c *gin.Context) {
+	// TODO should get collection with timeout
 	localCollection := context.CollectionFactory().LocalRepoCollection()
-	localCollection.RLock()
-	defer localCollection.RUnlock()
+	localCollection.Lock()
+	defer localCollection.Unlock()
 
 	snapshotCollection := context.CollectionFactory().SnapshotCollection()
-	snapshotCollection.RLock()
-	defer snapshotCollection.RUnlock()
+	snapshotCollection.Lock()
+	defer snapshotCollection.Unlock()
 
 	collection := context.CollectionFactory().PublishedRepoCollection()
-	collection.RLock()
-	defer collection.RUnlock()
+	collection.Lock()
+	defer collection.Unlock()
 
 	result := make([]*deb.PublishedRepo, 0, collection.Len())
 
@@ -124,8 +125,8 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 		var snapshot *deb.Snapshot
 
 		snapshotCollection := context.CollectionFactory().SnapshotCollection()
-		snapshotCollection.RLock()
-		defer snapshotCollection.RUnlock()
+		snapshotCollection.Lock()
+		defer snapshotCollection.Unlock()
 
 		for _, source := range b.Sources {
 			components = append(components, source.Component)
@@ -148,8 +149,8 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 		var localRepo *deb.LocalRepo
 
 		localCollection := context.CollectionFactory().LocalRepoCollection()
-		localCollection.RLock()
-		defer localCollection.RUnlock()
+		localCollection.Lock()
+		defer localCollection.Unlock()
 
 		for _, source := range b.Sources {
 			components = append(components, source.Component)
@@ -163,6 +164,7 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 			err = localCollection.LoadComplete(localRepo)
 			if err != nil {
 				c.Fail(500, fmt.Errorf("unable to publish: %s", err))
+				return
 			}
 
 			sources = append(sources, localRepo)
@@ -239,12 +241,12 @@ func apiPublishUpdateSwitch(c *gin.Context) {
 
 	// published.LoadComplete would touch local repo collection
 	localRepoCollection := context.CollectionFactory().LocalRepoCollection()
-	localRepoCollection.RLock()
-	defer localRepoCollection.RUnlock()
+	localRepoCollection.Lock()
+	defer localRepoCollection.Unlock()
 
 	snapshotCollection := context.CollectionFactory().SnapshotCollection()
-	snapshotCollection.RLock()
-	defer snapshotCollection.RUnlock()
+	snapshotCollection.Lock()
+	defer snapshotCollection.Unlock()
 
 	collection := context.CollectionFactory().PublishedRepoCollection()
 	collection.Lock()
@@ -336,8 +338,8 @@ func apiPublishDrop(c *gin.Context) {
 
 	// published.LoadComplete would touch local repo collection
 	localRepoCollection := context.CollectionFactory().LocalRepoCollection()
-	localRepoCollection.RLock()
-	defer localRepoCollection.RUnlock()
+	localRepoCollection.Lock()
+	defer localRepoCollection.Unlock()
 
 	collection := context.CollectionFactory().PublishedRepoCollection()
 	collection.Lock()

--- a/api/repos.go
+++ b/api/repos.go
@@ -161,7 +161,7 @@ func apiReposPackagesShow(c *gin.Context) {
 	collection := context.CollectionFactory().LocalRepoCollection()
 	ok := collection.TryLock(2 * time.Second)
 	if !ok {
-		err := fmt.Errorf("Unable to read packages for %s. Other process is locking resource.", name)
+		err := fmt.Errorf("Unable to read packages of repo %s. Other process is locking resource.", name)
 		c.Fail(500, err)
 		return
 	}

--- a/api/repos.go
+++ b/api/repos.go
@@ -9,7 +9,6 @@ import (
 	"github.com/smira/aptly/utils"
 	"os"
 	"path/filepath"
-	"time"
 )
 
 // GET /api/repos
@@ -159,7 +158,7 @@ func apiReposDrop(c *gin.Context) {
 func apiReposPackagesShow(c *gin.Context) {
 	name := c.Params.ByName("name")
 	collection := context.CollectionFactory().LocalRepoCollection()
-	ok := collection.TryLock(2 * time.Second)
+	ok := collection.TryLock(readTimeout)
 	if !ok {
 		err := fmt.Errorf("Unable to read packages of repo %s. Other process is locking resource.", name)
 		c.Fail(500, err)

--- a/api/router.go
+++ b/api/router.go
@@ -4,9 +4,11 @@ import (
 	"github.com/gin-gonic/gin"
 	ctx "github.com/smira/aptly/context"
 	"net/http"
+	"time"
 )
 
 var context *ctx.AptlyContext
+var readTimeout time.Duration
 
 // Router returns prebuilt with routes http.Handler
 func Router(c *ctx.AptlyContext) http.Handler {
@@ -14,6 +16,9 @@ func Router(c *ctx.AptlyContext) http.Handler {
 
 	router := gin.Default()
 	router.Use(gin.ErrorLogger())
+
+	timeout := context.Flags().Lookup("read-timeout").Value.Get().(int)
+	readTimeout = time.Duration(timeout) * time.Second
 
 	if context.Flags().Lookup("no-lock").Value.Get().(bool) {
 		// We use a goroutine to count the number of

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -46,8 +46,8 @@ func apiSnapshotsCreateFromMirror(c *gin.Context) {
 	}
 
 	collection := context.CollectionFactory().RemoteRepoCollection()
-	collection.RLock()
-	defer collection.RUnlock()
+	collection.Lock()
+	defer collection.Unlock()
 
 	snapshotCollection := context.CollectionFactory().SnapshotCollection()
 	snapshotCollection.Lock()

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"fmt"
-	"time"
 	"github.com/gin-gonic/gin"
 	"github.com/smira/aptly/database"
 	"github.com/smira/aptly/deb"
@@ -276,7 +275,7 @@ func apiSnapshotsUpdate(c *gin.Context) {
 func apiSnapshotsShow(c *gin.Context) {
 	name := c.Params.ByName("name")
 	collection := context.CollectionFactory().SnapshotCollection()
-	ok := collection.TryLock(2 * time.Second)
+	ok := collection.TryLock(readTimeout)
 	if !ok {
 		err := fmt.Errorf("Unable to read packages for snapshot %s. Other process is locking resource.", name)
 		c.Fail(500, err)
@@ -348,7 +347,7 @@ func apiSnapshotsDiff(c *gin.Context) {
 
 	name := c.Params.ByName("name")
 	collection := context.CollectionFactory().SnapshotCollection()
-	ok := collection.TryLock(2 * time.Second)
+	ok := collection.TryLock(readTimeout)
 	if !ok {
 		err := fmt.Errorf("Unable to read snapshot %s. Other process is locking resource.", name)
 		c.Fail(500, err)
@@ -404,7 +403,7 @@ func apiSnapshotsDiff(c *gin.Context) {
 func apiSnapshotsSearchPackages(c *gin.Context) {
 	name := c.Params.ByName("name")
 	collection := context.CollectionFactory().SnapshotCollection()
-	ok := collection.TryLock(2 * time.Second)
+	ok := collection.TryLock(readTimeout)
 	if !ok {
 		err := fmt.Errorf("Unable to read snapshot %s. Other process is locking resource.", name)
 		c.Fail(500, err)

--- a/cmd/api_serve.go
+++ b/cmd/api_serve.go
@@ -47,6 +47,7 @@ Example:
 
 	cmd.Flag.String("listen", ":8080", "host:port for HTTP listening")
 	cmd.Flag.Bool("no-lock", false, "don't lock the database")
+	cmd.Flag.Int("read-timeout", 2, "timeout in seconds GET requests wait for locking")
 
 	return cmd
 

--- a/deb/local.go
+++ b/deb/local.go
@@ -7,7 +7,6 @@ import (
 	"github.com/smira/go-uuid/uuid"
 	"github.com/ugorji/go/codec"
 	"log"
-	"sync"
 )
 
 // LocalRepo is a collection of packages created locally
@@ -91,7 +90,7 @@ func (repo *LocalRepo) RefKey() []byte {
 
 // LocalRepoCollection does listing, updating/adding/deleting of LocalRepos
 type LocalRepoCollection struct {
-	*sync.RWMutex
+	*Mutex
 	db   database.Storage
 	list []*LocalRepo
 }
@@ -99,8 +98,8 @@ type LocalRepoCollection struct {
 // NewLocalRepoCollection loads LocalRepos from DB and makes up collection
 func NewLocalRepoCollection(db database.Storage) *LocalRepoCollection {
 	result := &LocalRepoCollection{
-		RWMutex: &sync.RWMutex{},
-		db:      db,
+		Mutex: NewMutex(),
+		db:    db,
 	}
 
 	blobs := db.FetchByPrefix([]byte("L"))

--- a/deb/mutex.go
+++ b/deb/mutex.go
@@ -1,0 +1,66 @@
+package deb
+
+import (
+	"time"
+	"sync"
+)
+
+// TryLocker extends Locker interface with TryLock
+type TryLocker interface {
+	sync.Locker
+	TryLock(timeout time.Duration) bool
+}
+
+// Mutex implements mutex with channels and a timeout
+// possibility
+type Mutex struct {
+	c chan struct{}
+}
+
+// NewMutex creates a new empty mutex
+func NewMutex() *Mutex {
+	return &Mutex{make(chan struct{}, 1)}
+}
+
+// TryLockMutexes tries to lock all mutexes if one fails it will return will
+// false and cleans up locks
+func TryLockMutexes(timeout time.Duration, mutexes ...TryLocker) bool {
+	var lockedMutexes []TryLocker
+	for _, mu := range mutexes {
+		ok := mu.TryLock(timeout)
+		if !ok {
+			// clean up locks
+			for _, lmu := range lockedMutexes {
+				lmu.Unlock()
+			}
+			return false
+		}
+
+		lockedMutexes = append(lockedMutexes, mu)
+	}
+
+	return true
+}
+
+// Lock locks mutex
+func (m *Mutex) Lock() {
+	m.c <- struct{}{}
+}
+
+// Unlock unlocks mutex
+func (m *Mutex) Unlock() {
+	<-m.c
+}
+
+// TryLock tries to lock with a wait timeout
+func (m *Mutex) TryLock(timeout time.Duration) bool {
+	// TODO configure timeout in aptly configuration
+	timer := time.NewTimer(timeout)
+	select {
+	case m.c <- struct{}{}:
+		timer.Stop()
+		return true
+	case <-time.After(timeout):
+	}
+	return false
+}

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -749,7 +748,7 @@ func (p *PublishedRepo) RemoveFiles(publishedStorageProvider aptly.PublishedStor
 
 // PublishedRepoCollection does listing, updating/adding/deleting of PublishedRepos
 type PublishedRepoCollection struct {
-	*sync.RWMutex
+	*Mutex
 	db   database.Storage
 	list []*PublishedRepo
 }
@@ -757,8 +756,8 @@ type PublishedRepoCollection struct {
 // NewPublishedRepoCollection loads PublishedRepos from DB and makes up collection
 func NewPublishedRepoCollection(db database.Storage) *PublishedRepoCollection {
 	result := &PublishedRepoCollection{
-		RWMutex: &sync.RWMutex{},
-		db:      db,
+		Mutex: NewMutex(),
+		db:    db,
 	}
 
 	blobs := db.FetchByPrefix([]byte("U"))

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -17,7 +17,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 )
@@ -613,7 +612,7 @@ func (repo *RemoteRepo) RefKey() []byte {
 
 // RemoteRepoCollection does listing, updating/adding/deleting of RemoteRepos
 type RemoteRepoCollection struct {
-	*sync.RWMutex
+	*Mutex
 	db   database.Storage
 	list []*RemoteRepo
 }
@@ -621,8 +620,8 @@ type RemoteRepoCollection struct {
 // NewRemoteRepoCollection loads RemoteRepos from DB and makes up collection
 func NewRemoteRepoCollection(db database.Storage) *RemoteRepoCollection {
 	result := &RemoteRepoCollection{
-		RWMutex: &sync.RWMutex{},
-		db:      db,
+		Mutex: NewMutex(),
+		db:    db,
 	}
 
 	blobs := db.FetchByPrefix([]byte("R"))

--- a/deb/snapshot.go
+++ b/deb/snapshot.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"sort"
 	"strings"
-	"sync"
 	"time"
 )
 
@@ -162,7 +161,7 @@ func (s *Snapshot) Decode(input []byte) error {
 
 // SnapshotCollection does listing, updating/adding/deleting of Snapshots
 type SnapshotCollection struct {
-	*sync.RWMutex
+	*Mutex
 	db   database.Storage
 	list []*Snapshot
 }
@@ -170,8 +169,8 @@ type SnapshotCollection struct {
 // NewSnapshotCollection loads Snapshots from DB and makes up collection
 func NewSnapshotCollection(db database.Storage) *SnapshotCollection {
 	result := &SnapshotCollection{
-		RWMutex: &sync.RWMutex{},
-		db:      db,
+		Mutex: NewMutex(),
+		db:    db,
 	}
 
 	blobs := db.FetchByPrefix([]byte("S"))


### PR DESCRIPTION
This is a simple solution that get requests do not lock when a write process is being processed. Complex get requests timeout after defined time in seconds. Simple get requests do not need any locking anymore and get information from database directly.

This is the basis to get queuing and mirror api included to get us moving.

For upstream I think a more complete solution would be needed. A transaction layer needs to be defined for the goleveldb and collections are not global resources anymore but newly built with infos from db for each request. This will need some more time to implement though.