### PR TITLE
old contents reference in db need to be clean up

### DIFF
--- a/database/leveldb.go
+++ b/database/leveldb.go
@@ -28,6 +28,7 @@ type Storage interface {
 	KeysByPrefix(prefix []byte) [][]byte
 	FetchByPrefix(prefix []byte) [][]byte
 	ProcessByPrefix(prefix []byte, proc StorageProcessor) error
+	DeleteByPrefix(prefix []byte) error
 	Close() error
 	ReOpen() error
 	StartBatch() *leveldb.Batch
@@ -153,6 +154,21 @@ func (l *levelDB) ProcessByPrefix(prefix []byte, proc StorageProcessor) error {
 		err := proc(iterator.Key(), iterator.Value())
 		if err != nil {
 			return err
+		}
+	}
+
+	return nil
+}
+
+// DeleteByPrefix deletes all entries with given prefix
+func (l *levelDB) DeleteByPrefix(prefix []byte) error {
+	iterator := l.db.NewIterator(nil, nil)
+	defer iterator.Release()
+
+	for ok := iterator.Seek(prefix); ok && bytes.HasPrefix(iterator.Key(), prefix); ok = iterator.Next() {
+		key := iterator.Key()
+		if err := l.Delete(key); err != nil {
+			return nil
 		}
 	}
 

--- a/database/leveldb.go
+++ b/database/leveldb.go
@@ -165,14 +165,13 @@ func (l *levelDB) DeleteByPrefix(prefix []byte) error {
 	iterator := l.db.NewIterator(nil, nil)
 	defer iterator.Release()
 
+	batch := l.StartBatch()
 	for ok := iterator.Seek(prefix); ok && bytes.HasPrefix(iterator.Key(), prefix); ok = iterator.Next() {
 		key := iterator.Key()
-		if err := l.Delete(key); err != nil {
-			return nil
-		}
+		batch.Delete(key)
 	}
 
-	return nil
+	return l.FinishBatch(batch)
 }
 
 // FetchByPrefix returns all values with keys that start with prefix

--- a/deb/contents.go
+++ b/deb/contents.go
@@ -19,7 +19,13 @@ type ContentsIndex struct {
 
 // NewContentsIndex creates empty ContentsIndex
 func NewContentsIndex(db database.Storage, repo PublishedRepo, component string, architecture string, udeb bool) *ContentsIndex {
-	return &ContentsIndex{db: db, repo: repo, component: component, architecture: architecture}
+	index := &ContentsIndex{db: db, repo: repo, component: component, architecture: architecture}
+
+	// clean up old values
+	key := index.Key("", "")
+	db.DeleteByPrefix(key)
+
+	return index
 }
 
 // Key generates unique identifier for contents index file with given path and package name


### PR DESCRIPTION
The database is persistent, so when a new contents index is created we need to make sure that all referencing contents values are deleted.