### PR TITLE
Do not write bytes to output which are only meant for progress bar on cmd

### DIFF
--- a/api/repos.go
+++ b/api/repos.go
@@ -200,7 +200,7 @@ func apiReposPackagesAddDelete(c *gin.Context, taskNamePrefix string, cb func(li
 
 	resources := []string{string(repo.Key())}
 	task, conflictErr := runTaskInBackground(taskNamePrefix + repo.Name, resources, func(out *task.Output) error {
-		fmt.Fprintln(out, "Loading packages...")
+		out.Print("Loading packages...\n")
 		list, err := deb.NewPackageListFromRefList(repo.RefList(), collectionFactory.PackageCollection(), nil)
 		if err != nil {
 			return err
@@ -241,7 +241,7 @@ func apiReposPackagesAddDelete(c *gin.Context, taskNamePrefix string, cb func(li
 // POST /repos/:name/packages
 func apiReposPackagesAdd(c *gin.Context) {
 	apiReposPackagesAddDelete(c, "Add packages to repo ", func(list *deb.PackageList, p *deb.Package, out *task.Output) error {
-		fmt.Fprintf(out, "Adding package %s", p.Name)
+		out.Printf("Adding package %s\n", p.Name)
 		return list.Add(p)
 	})
 }
@@ -249,7 +249,7 @@ func apiReposPackagesAdd(c *gin.Context) {
 // DELETE /repos/:name/packages
 func apiReposPackagesDelete(c *gin.Context) {
 	apiReposPackagesAddDelete(c, "Delete packages from repo ", func(list *deb.PackageList, p *deb.Package, out *task.Output) error {
-		fmt.Fprintf(out, "Removing package %s", p.Name)
+		out.Printf("Removing package %s\n", p.Name)
 		list.Remove(p)
 		return nil
 	})
@@ -361,16 +361,16 @@ func apiReposPackageFromDir(c *gin.Context) {
 		}
 
 		if len(reporter.AddedLines) > 0 {
-			fmt.Fprintf(out, "Added: %s", strings.Join(reporter.AddedLines, ", "))
+			out.Printf("Added: %s\n", strings.Join(reporter.AddedLines, ", "))
 		}
 		if len(reporter.RemovedLines) > 0 {
-			fmt.Fprintf(out, "Removed: %s", strings.Join(reporter.RemovedLines, ", "))
+			out.Printf("Removed: %s\n", strings.Join(reporter.RemovedLines, ", "))
 		}
 		if len(reporter.Warnings) > 0 {
-			fmt.Fprintf(out, "Warnings: %s", strings.Join(reporter.Warnings, ", "))
+			out.Printf("Warnings: %s\n", strings.Join(reporter.Warnings, ", "))
 		}
 		if len(failedFiles) > 0 {
-			fmt.Fprintf(out, "Failed files: %s", strings.Join(failedFiles, ", "))
+			out.Printf("Failed files: %s\n", strings.Join(failedFiles, ", "))
 		}
 
 		return nil

--- a/task/list.go
+++ b/task/list.go
@@ -1,7 +1,6 @@
 package task
 
 import (
-	"bytes"
 	"fmt"
 	"sync"
 )
@@ -87,13 +86,7 @@ func (list *List) RunTaskInBackground(name string, resources []string, process f
 
 	list.idCounter++
 	wgTask := &sync.WaitGroup{}
-	task := &Task{
-		output:  &Output{mu: &sync.Mutex{}, output: &bytes.Buffer{}},
-		process: process,
-		Name:    name,
-		ID:      list.idCounter,
-		State:   IDLE,
-	}
+	task := NewTask(process, name, list.idCounter)
 
 	list.tasks = append(list.tasks, task)
 	list.wgTasks[task.ID] = wgTask
@@ -115,10 +108,10 @@ func (list *List) RunTaskInBackground(name string, resources []string, process f
 		list.Lock()
 		{
 			if err != nil {
-				fmt.Fprintf(task.output, "Task failed with error: %v\n", err)
+				task.output.Printf("Task failed with error: %v", err)
 				task.State = FAILED
 			} else {
-				fmt.Fprintln(task.output, "Task succeeded")
+				task.output.Print("Task succeeded")
 				task.State = SUCCEEDED
 			}
 

--- a/task/list_test.go
+++ b/task/list_test.go
@@ -2,16 +2,10 @@ package task
 
 import (
 	"errors"
-	"testing"
 
 	// need to import as check as otherwise List is redeclared
 	check "gopkg.in/check.v1"
 )
-
-// Launch gocheck tests
-func Test(t *testing.T) {
-	check.TestingT(t)
-}
 
 type ListSuite struct{}
 
@@ -32,7 +26,7 @@ func (s *ListSuite) TestList(c *check.C) {
 	task, _ = list.GetTaskByID(task.ID)
 	c.Check(task.State, check.Equals, SUCCEEDED)
 	output, _ := list.GetTaskOutputByID(task.ID)
-	c.Check(output, check.Equals, "Task succeeded\n")
+	c.Check(output, check.Equals, "Task succeeded")
 
 	task, err = list.RunTaskInBackground("Faulty task", nil, func(out *Output) error {
 		out.WriteString("Test Progress\n")
@@ -46,5 +40,5 @@ func (s *ListSuite) TestList(c *check.C) {
 	task, _ = list.GetTaskByID(task.ID)
 	c.Check(task.State, check.Equals, FAILED)
 	output, _ = list.GetTaskOutputByID(task.ID)
-	c.Check(output, check.Equals, "Test Progress\nTask failed with error: Task failed\n")
+	c.Check(output, check.Equals, "Test Progress\nTask failed with error: Task failed")
 }

--- a/task/output.go
+++ b/task/output.go
@@ -1,0 +1,90 @@
+package task
+
+import (
+	"fmt"
+	"sync"
+	"bytes"
+)
+
+// Output represents a safe standard output of task
+// which is compatbile to AptlyProgress.
+type Output struct {
+	mu *sync.Mutex
+	output *bytes.Buffer
+}
+
+// NewOutput creates new output
+func NewOutput() *Output {
+	return &Output{mu: &sync.Mutex{}, output: &bytes.Buffer{}}
+}
+
+func (t *Output) String() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.output.String()
+}
+
+// Write is used to determine how many bytes have been written
+// not needed in our case.
+func (t *Output) Write(p []byte) (n int, err error) {
+	return len(p), err
+}
+
+// WriteString writes string to output
+func (t *Output) WriteString(s string) (n int, err error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.output.WriteString(s)
+}
+
+// Start is needed for progress compatability
+func (t *Output) Start() {
+	// Not implemented
+}
+
+// Shutdown is needed for progress compatability
+func (t *Output) Shutdown() {
+	// Not implemented
+}
+
+// Flush is needed for progress compatability
+func (t *Output) Flush() {
+	// Not implemented
+}
+
+// InitBar is needed for progress compatability
+func (t *Output) InitBar(count int64, isBytes bool) {
+	// Not implemented
+}
+
+// ShutdownBar is needed for progress compatability
+func (t *Output) ShutdownBar() {
+	// Not implemented
+}
+
+// AddBar is needed for progress compatability
+func (t *Output) AddBar(count int) {
+	// Not implemented
+}
+
+// SetBar sets current position for progress bar
+func (t *Output) SetBar(count int) {
+	// Not implemented
+}
+
+// Printf does printf in a safe manner
+func (t *Output) Printf(msg string, a ...interface{}) {
+	t.WriteString(fmt.Sprintf(msg, a...))
+}
+
+// Print does printf in a safe manner
+func (t *Output) Print(msg string) {
+	t.WriteString(msg)
+}
+
+// ColoredPrintf does printf in a safe manner + newline
+// currently are no colors supported.
+func (t *Output) ColoredPrintf(msg string, a ...interface{}) {
+	t.WriteString(fmt.Sprintf(msg + "\n", a...))
+}

--- a/task/task.go
+++ b/task/task.go
@@ -1,11 +1,5 @@
 package task
 
-import (
-	"bytes"
-	"sync"
-	"fmt"
-)
-
 // State task is in
 type State int
 
@@ -29,74 +23,14 @@ type Task struct {
 	State   State
 }
 
-// Output represents a safe standard output of task
-// which is compatbile to AptlyProgress
-type Output struct {
-	mu     *sync.Mutex
-	output *bytes.Buffer
-}
-
-func (t *Output) String() string {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.output.String()
-}
-
-func (t *Output) Write(p []byte) (n int, err error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.output.Write(p)
-}
-
-// WriteString writes string to output
-func (t *Output) WriteString(s string) (n int, err error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	return t.output.WriteString(s)
-}
-
-// Start is needed for progress compatability
-func (t *Output) Start() {
-	// Not implemented
-}
-
-// Shutdown is needed for progress compatability
-func (t *Output) Shutdown() {
-	// Not implemented
-}
-
-// Flush is needed for progress compatability
-func (t *Output) Flush() {
-	// Not implemented
-}
-
-// InitBar is needed for progress compatability
-func (t *Output) InitBar(count int64, isBytes bool) {
-	// Not implemented
-}
-
-// ShutdownBar is needed for progress compatability
-func (t *Output) ShutdownBar() {
-	// Not implemented
-}
-
-// AddBar is needed for progress compatability
-func (t* Output) AddBar(count int) {
-	// Not implemented
-}
-
-// SetBar sets current position for progress bar
-func (t* Output) SetBar(count int) {
-	// Not implemented
-}
-
-// Printf does printf in a safe manner
-func (t* Output) Printf(msg string, a ...interface{}) {
-	fmt.Fprintf(t, msg, a)
-}
-
-// ColoredPrintf does printf in a safe manner + newline
-// currently are now colors supported.
-func (t* Output) ColoredPrintf(msg string, a ...interface{}) {
-	t.Printf(msg + "\n", a)
+// NewTask creates new task
+func NewTask(process func(out *Output) error, name string, ID int) *Task {
+	task := &Task{
+		output:  NewOutput(),
+		process: process,
+		Name:    name,
+		ID:      ID,
+		State:   IDLE,
+	}
+	return task
 }

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -1,0 +1,12 @@
+package task
+
+import (
+	"testing"
+
+	check "gopkg.in/check.v1"
+)
+
+// Launch gocheck tests
+func Test(t *testing.T) {
+	check.TestingT(t)
+}


### PR DESCRIPTION
Write bytes method on Progress is only used for progress bar and input
should not be logged. Such was done in output which led to out of memory
issue