### PR TITLE
Generic solution to store custom details on a task

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -81,8 +81,8 @@ func releaseDatabaseConnection() error {
 }
 
 // runs tasks in background. Acquires database connection first.
-func runTaskInBackground(name string, resources []string, proc func(out *task.Output) error) (task.Task, *task.ResourceConflictError) {
-	return context.TaskList().RunTaskInBackground(name, resources, func(out *task.Output) error {
+func runTaskInBackground(name string, resources []string, proc task.Process) (task.Task, *task.ResourceConflictError) {
+	return context.TaskList().RunTaskInBackground(name, resources, func(out *task.Output, detail *task.Detail) error {
 		err := acquireDatabaseConnection()
 
 		if err != nil {
@@ -90,7 +90,7 @@ func runTaskInBackground(name string, resources []string, proc func(out *task.Ou
 		}
 
 		defer releaseDatabaseConnection()
-		return proc(out)
+		return proc(out, detail)
 	})
 }
 

--- a/api/publish.go
+++ b/api/publish.go
@@ -177,7 +177,7 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 	collection := collectionFactory.PublishedRepoCollection()
 
 	taskName := fmt.Sprintf("Publish %s: %s", b.SourceKind, strings.Join(names, ", "))
-	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output) error {
+	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
 		published.Origin = b.Origin
 		published.Label = b.Label
 
@@ -303,7 +303,7 @@ func apiPublishUpdateSwitch(c *gin.Context) {
 
 	resources = append(resources, string(published.Key()))
 	taskName := fmt.Sprintf("Update published %s (%s): %s", published.SourceKind, strings.Join(updatedComponents, " "), strings.Join(updatedSnapshots, ", "))
-	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output) error {
+	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
 		err := published.Publish(context.PackagePool(), context, collectionFactory, signer, out, b.ForceOverwrite)
 		if err != nil {
 			return fmt.Errorf("unable to update: %s", err)
@@ -353,7 +353,7 @@ func apiPublishDrop(c *gin.Context) {
 	resources := []string{string(published.Key())}
 
 	taskName := fmt.Sprintf("Delete published %s (%s)", prefix, distribution)
-	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output) error {
+	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
 		err := collection.Remove(context, storage, prefix, distribution,
 			collectionFactory, out, force)
 		if err != nil {

--- a/api/repos.go
+++ b/api/repos.go
@@ -128,7 +128,7 @@ func apiReposDrop(c *gin.Context) {
 
 	resources := []string{string(repo.Key())}
 	taskName := fmt.Sprintf("Delete repo %s", name)
-	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output) error {
+	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
 		published := publishedCollection.ByLocalRepo(repo)
 		if len(published) > 0 {
 			return fmt.Errorf("unable to drop, local repo is published")
@@ -199,7 +199,7 @@ func apiReposPackagesAddDelete(c *gin.Context, taskNamePrefix string, cb func(li
 	}
 
 	resources := []string{string(repo.Key())}
-	task, conflictErr := runTaskInBackground(taskNamePrefix + repo.Name, resources, func(out *task.Output) error {
+	task, conflictErr := runTaskInBackground(taskNamePrefix + repo.Name, resources, func(out *task.Output, detail *task.Detail) error {
 		out.Print("Loading packages...\n")
 		list, err := deb.NewPackageListFromRefList(repo.RefList(), collectionFactory.PackageCollection(), nil)
 		if err != nil {
@@ -299,7 +299,7 @@ func apiReposPackageFromDir(c *gin.Context) {
 	}
 
 	resources := []string{string(repo.Key())}
-	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output) error {
+	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
 		verifier := &utils.GpgVerifier{}
 
 		var (

--- a/api/router.go
+++ b/api/router.go
@@ -120,6 +120,7 @@ func Router(c *ctx.AptlyContext) http.Handler {
 		root.GET("/tasks-wait", apiTasksWait)
 		root.GET("/tasks/:id/wait", apiTasksWaitForTaskByID)
 		root.GET("/tasks/:id/output", apiTasksOutputShow)
+		root.GET("/tasks/:id/detail", apiTasksDetailShow)
 		root.GET("/tasks/:id", apiTasksShow)
 	}
 

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -59,7 +59,7 @@ func apiSnapshotsCreateFromMirror(c *gin.Context) {
 	// including snapshot resource key
 	resources := []string{string(repo.Key()), "S" + b.Name}
 	taskName := fmt.Sprintf("Create snapshot of mirror %s", name)
-	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output) error {
+	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
 		err := repo.CheckLock()
 		if err != nil {
 			return err
@@ -137,7 +137,7 @@ func apiSnapshotsCreate(c *gin.Context) {
 		resources = append(resources, string(sources[i].ResourceKey()))
 	}
 
-	task, conflictErr := runTaskInBackground("Create snapshot " + b.Name, resources, func(out *task.Output) error {
+	task, conflictErr := runTaskInBackground("Create snapshot " + b.Name, resources, func(out *task.Output, detail *task.Detail) error {
 		list := deb.NewPackageList()
 
 		// verify package refs and build package list
@@ -200,7 +200,7 @@ func apiSnapshotsCreateFromRepository(c *gin.Context) {
 	// including snapshot resource key
 	resources := []string{string(repo.Key()), "S" + b.Name}
 	taskName := fmt.Sprintf("Create snapshot of repo %s", name)
-	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output) error {
+	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
 		err := collection.LoadComplete(repo)
 		if err != nil {
 			return err
@@ -255,7 +255,7 @@ func apiSnapshotsUpdate(c *gin.Context) {
 
 	resources := []string{string(snapshot.ResourceKey()), "S" + b.Name}
 	taskName := fmt.Sprintf("Update snapshot %s", name)
-	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output) error {
+	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
 		_, err := collection.ByName(b.Name)
 		if err == nil {
 			return fmt.Errorf("unable to rename: snapshot %s already exists", b.Name)
@@ -319,7 +319,7 @@ func apiSnapshotsDrop(c *gin.Context) {
 
 	resources := []string{string(snapshot.ResourceKey())}
 	taskName := fmt.Sprintf("Delete snapshot %s", name)
-	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output) error {
+	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
 		published := publishedCollection.BySnapshot(snapshot)
 
 		if len(published) > 0 {

--- a/api/task.go
+++ b/api/task.go
@@ -3,8 +3,8 @@ package api
 import (
 	"strconv"
 
-	"github.com/smira/aptly/task"
 	"github.com/gin-gonic/gin"
+	"github.com/smira/aptly/task"
 )
 
 // GET /tasks
@@ -76,9 +76,28 @@ func apiTasksOutputShow(c *gin.Context) {
 	var output string
 	output, err = list.GetTaskOutputByID(int(id))
 	if err != nil {
-		c.Fail(500, err)
+		c.Fail(404, err)
 		return
 	}
 
 	c.JSON(200, output)
+}
+
+// GET /tasks/:id/detail
+func apiTasksDetailShow(c *gin.Context) {
+	list := context.TaskList()
+	id, err := strconv.ParseInt(c.Params.ByName("id"), 10, 0)
+	if err != nil {
+		c.Fail(500, err)
+		return
+	}
+
+	var detail interface{}
+	detail, err = list.GetTaskDetailByID(int(id))
+	if err != nil {
+		c.Fail(404, err)
+		return
+	}
+
+	c.JSON(200, detail)
 }

--- a/system/t12_api/mirrors.py
+++ b/system/t12_api/mirrors.py
@@ -58,6 +58,12 @@ class MirrorsAPITestCreateUpdate(APITest):
         resp = self.put_task("/api/mirrors/" + mirror_name, json=mirror_desc)
         self.check_equal(resp.json()["State"], 2)
 
+        _id = resp.json()['ID']
+        resp = self.get("/api/tasks/" + str(_id) + "/detail")
+        self.check_equal(resp.status_code, 200)
+        self.check_equal(resp.json()['RemainingDownloadSize'], 0)
+        self.check_equal(resp.json()['RemainingNumberOfPackages'], 0)
+
         resp = self.get("/api/mirrors/" + mirror_desc["Name"])
         self.check_equal(resp.status_code, 200)
         self.check_subset({u'Name': mirror_desc["Name"],

--- a/task/task.go
+++ b/task/task.go
@@ -1,7 +1,19 @@
 package task
 
+import (
+	"sync/atomic"
+)
+
 // State task is in
 type State int
+
+// Detail represents custom task details
+type Detail struct {
+	atomic.Value
+}
+
+// Process is a function implementing the actual task logic
+type Process func(out *Output, detail *Detail) error
 
 const (
 	// IDLE when task is waiting
@@ -17,16 +29,18 @@ const (
 // Task represents as task in a queue encapsulates process code
 type Task struct {
 	output  *Output
-	process func(out *Output) error
+	detail  *Detail
+	process Process
 	Name    string
 	ID      int
 	State   State
 }
 
 // NewTask creates new task
-func NewTask(process func(out *Output) error, name string, ID int) *Task {
+func NewTask(process Process, name string, ID int) *Task {
 	task := &Task{
 		output:  NewOutput(),
+		detail:  &Detail{},
 		process: process,
 		Name:    name,
 		ID:      ID,


### PR DESCRIPTION
Such details can be retrieved on api with /tasks/:id/detail. For now only mirror update command stores details.