### PR TITLE
Adjusted status code of api

### DIFF
--- a/api/mirror.go
+++ b/api/mirror.go
@@ -111,7 +111,7 @@ func apiMirrorsCreate(c *gin.Context) {
 	downloader := context.NewDownloader(nil)
 	err = repo.Fetch(downloader, verifier)
 	if err != nil {
-		c.Fail(403, fmt.Errorf("unable to fetch mirror: %s", err))
+		c.Fail(400, fmt.Errorf("unable to fetch mirror: %s", err))
 		return
 	}
 
@@ -160,7 +160,7 @@ func apiMirrorsDrop(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 
@@ -205,7 +205,7 @@ func apiMirrorsPackages(c *gin.Context) {
 	}
 
 	if repo.LastDownloadDate.IsZero() {
-		c.Fail(403, fmt.Errorf("Unable to show package list, mirror hasn't been downloaded yet."))
+		c.Fail(404, fmt.Errorf("Unable to show package list, mirror hasn't been downloaded yet."))
 		return
 	}
 
@@ -443,7 +443,7 @@ func apiMirrorsUpdate(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 

--- a/api/publish.go
+++ b/api/publish.go
@@ -207,7 +207,7 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 
@@ -325,7 +325,7 @@ func apiPublishUpdateSwitch(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 
@@ -365,7 +365,7 @@ func apiPublishDrop(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 

--- a/api/repos.go
+++ b/api/repos.go
@@ -146,7 +146,7 @@ func apiReposDrop(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 
@@ -231,7 +231,7 @@ func apiReposPackagesAddDelete(c *gin.Context, taskNamePrefix string, cb func(li
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 
@@ -378,7 +378,7 @@ func apiReposPackageFromDir(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 

--- a/api/snapshot.go
+++ b/api/snapshot.go
@@ -84,7 +84,7 @@ func apiSnapshotsCreateFromMirror(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 
@@ -162,7 +162,7 @@ func apiSnapshotsCreate(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 
@@ -220,7 +220,7 @@ func apiSnapshotsCreateFromRepository(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 
@@ -275,7 +275,7 @@ func apiSnapshotsUpdate(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 
@@ -338,7 +338,7 @@ func apiSnapshotsDrop(c *gin.Context) {
 
 	if conflictErr != nil {
 		c.Error(conflictErr, conflictErr.Tasks)
-		c.AbortWithStatus(412)
+		c.AbortWithStatus(409)
 		return
 	}
 

--- a/system/t12_api/mirrors.py
+++ b/system/t12_api/mirrors.py
@@ -14,7 +14,7 @@ class MirrorsAPITestCreateShow(APITest):
                        u'Distribution': 'oldstable-proposed-updates'}
 
         resp = self.post("/api/mirrors", json=mirror_desc)
-        self.check_equal(resp.status_code, 403)
+        self.check_equal(resp.status_code, 400)
         self.check_equal([{
             'error': 'unable to fetch mirror: verification of detached signature failed: exit status 2',
             'meta': 'Operation aborted'
@@ -33,7 +33,7 @@ class MirrorsAPITestCreateShow(APITest):
                            u'Distribution': 'oldstable-proposed-updates'}, resp.json())
 
         resp = self.get("/api/mirrors/" + mirror_desc["Name"] + "/packages")
-        self.check_equal(resp.status_code, 403)
+        self.check_equal(resp.status_code, 404)
 
 
 class MirrorsAPITestCreateUpdate(APITest):
@@ -52,7 +52,7 @@ class MirrorsAPITestCreateUpdate(APITest):
         self.check_equal(resp.status_code, 201)
 
         resp = self.get("/api/mirrors/" + mirror_name + "/packages")
-        self.check_equal(resp.status_code, 403)
+        self.check_equal(resp.status_code, 404)
 
         mirror_desc["Name"] = self.random_name()
         resp = self.put_task("/api/mirrors/" + mirror_name, json=mirror_desc)

--- a/system/t12_api/tasks.py
+++ b/system/t12_api/tasks.py
@@ -20,7 +20,7 @@ class TaskAPITestParallelTasks(APITest):
 
         # check that two mirror updates cannot run at the same time
         resp2 = self.put("/api/mirrors/" + mirror_name, json=mirror_desc)
-        self.check_equal(resp2.status_code, 412)
+        self.check_equal(resp2.status_code, 409)
 
         return resp.json()['ID'], mirror_name
 


### PR DESCRIPTION
* Removed 403 status codes and replaced with 400, 404 depending on context
* Replacing 412 with 409 to determine when a task can not be run because resource is busy. 409 Conflict is more accurate than 412.