### PR TITLE
Task details should be empty for tasks which haven't stored details yet

### DIFF
--- a/task/list.go
+++ b/task/list.go
@@ -98,7 +98,7 @@ func (list *List) GetTaskDetailByID(ID int) (interface{}, error) {
 
 	detail := task.detail.Load()
 	if detail == nil {
-		return nil, fmt.Errorf("There are no details for task with id %v", ID)
+		return struct{}{}, nil
 	}
 
 	return detail, nil

--- a/task/list_test.go
+++ b/task/list_test.go
@@ -27,6 +27,8 @@ func (s *ListSuite) TestList(c *check.C) {
 	c.Check(task.State, check.Equals, SUCCEEDED)
 	output, _ := list.GetTaskOutputByID(task.ID)
 	c.Check(output, check.Equals, "Task succeeded")
+	detail, _ := list.GetTaskDetailByID(task.ID)
+	c.Check(detail, check.Equals, struct{}{})
 
 	task, err = list.RunTaskInBackground("Faulty task", nil, func(out *Output, detail *Detail) error {
 		detail.Store("Details")
@@ -42,7 +44,7 @@ func (s *ListSuite) TestList(c *check.C) {
 	c.Check(task.State, check.Equals, FAILED)
 	output, _ = list.GetTaskOutputByID(task.ID)
 	c.Check(output, check.Equals, "Test Progress\nTask failed with error: Task failed")
-	detail, _ := list.GetTaskDetailByID(task.ID)
+	detail, _ = list.GetTaskDetailByID(task.ID)
 	c.Check(detail, check.Equals, "Details")
 	_, deleteErr := list.DeleteTaskByID(task.ID)
 	c.Check(deleteErr, check.IsNil)


### PR DESCRIPTION
Fixes #26 

It is implemented the way that "/api/tasks/:id/detail" will return status code 200 unless task is invalid. For task without specific details such details will be an empty json.