### PR TITLE
 Add publish output progress counting remaining number of packages

### DIFF
--- a/api/publish.go
+++ b/api/publish.go
@@ -182,6 +182,14 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 
 	taskName := fmt.Sprintf("Publish %s: %s", b.SourceKind, strings.Join(names, ", "))
 	task, conflictErr := runTaskInBackground(taskName, resources, func(out *task.Output, detail *task.Detail) error {
+		taskDetail := task.PublishDetail{
+			Detail: detail,
+		}
+		publishOutput := &task.PublishOutput{
+			Output:        out,
+			PublishDetail: taskDetail,
+		}
+
 		if b.Origin != "" {
 			published.Origin = b.Origin
 		}
@@ -204,7 +212,7 @@ func apiPublishRepoOrSnapshot(c *gin.Context) {
 			return fmt.Errorf("prefix/distribution already used by another published repo: %s", duplicate)
 		}
 
-		err := published.Publish(context.PackagePool(), context, collectionFactory, signer, out, b.ForceOverwrite)
+		err := published.Publish(context.PackagePool(), context, collectionFactory, signer, publishOutput, b.ForceOverwrite)
 		if err != nil {
 			return fmt.Errorf("unable to publish: %s", err)
 		}

--- a/aptly/interfaces.go
+++ b/aptly/interfaces.go
@@ -87,6 +87,36 @@ type PublishedStorageProvider interface {
 	GetPublishedStorage(name string) PublishedStorage
 }
 
+// BarType used to differentiate between different progress bars
+type BarType int
+
+const (
+	// BarGeneralBuildPackageList identifies bar for building package list
+	BarGeneralBuildPackageList BarType = iota
+	// BarGeneralVerifyDependencies identifies bar for verifying dependencies
+	BarGeneralVerifyDependencies
+	// BarGeneralBuildFileList identifies bar for building file list
+	BarGeneralBuildFileList
+	// BarCleanupBuildList identifies bar for building list to cleanup
+	BarCleanupBuildList
+	// BarCleanupDeleteUnreferencedFiles identifies bar for deleting unreferenced files
+	BarCleanupDeleteUnreferencedFiles
+	// BarMirrorUpdateDownloadIndexes identifies bar for downloading index files
+	BarMirrorUpdateDownloadIndexes
+	// BarMirrorUpdateDownloadPackages identifies bar for downloading packages
+	BarMirrorUpdateDownloadPackages
+	// BarMirrorUpdateBuildPackageList identifies bar for building package list of downloaded files
+	BarMirrorUpdateBuildPackageList
+	// BarMirrorUpdateImportFiles identifies bar for importing package files
+	BarMirrorUpdateImportFiles
+	// BarMirrorUpdateFinalizeDownload identifies bar for finalizing downloads
+	BarMirrorUpdateFinalizeDownload
+	// BarPublishGeneratePackageFiles identifies bar for generating package files to publish
+	BarPublishGeneratePackageFiles
+	// BarPublishFinalizeIndexes identifies bar for finalizing index files
+	BarPublishFinalizeIndexes
+)
+
 // Progress is a progress displaying entity, it allows progress bars & simple prints
 type Progress interface {
 	// Writer interface to support progress bar ticking
@@ -98,7 +128,7 @@ type Progress interface {
 	// Flush returns when all queued messages are sent
 	Flush()
 	// InitBar starts progressbar for count bytes or count items
-	InitBar(count int64, isBytes bool)
+	InitBar(count int64, isBytes bool, barType BarType)
 	// ShutdownBar stops progress bar and hides it
 	ShutdownBar()
 	// AddBar increments progress for progress bar

--- a/cmd/db_cleanup.go
+++ b/cmd/db_cleanup.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/smira/aptly/aptly"
 	"github.com/smira/aptly/deb"
 	"github.com/smira/aptly/utils"
 	"github.com/smira/commander"
@@ -194,7 +195,7 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 	// now, build a list of files that should be present in Repository (package pool)
 	context.Progress().ColoredPrintf("@{w!}Building list of files referenced by packages...@|")
 	referencedFiles := make([]string, 0, existingPackageRefs.Len())
-	context.Progress().InitBar(int64(existingPackageRefs.Len()), false)
+	context.Progress().InitBar(int64(existingPackageRefs.Len()), false, aptly.BarCleanupBuildList)
 
 	err = existingPackageRefs.ForEach(func(key []byte) error {
 		pkg, err2 := collectionFactory.PackageCollection().ByKey(key)
@@ -248,7 +249,7 @@ func aptlyDbCleanup(cmd *commander.Command, args []string) error {
 		}
 
 		if !dryRun {
-			context.Progress().InitBar(int64(len(filesToDelete)), false)
+			context.Progress().InitBar(int64(len(filesToDelete)), false, aptly.BarCleanupDeleteUnreferencedFiles)
 
 			var size, totalSize int64
 			for _, file := range filesToDelete {

--- a/cmd/mirror_update.go
+++ b/cmd/mirror_update.go
@@ -130,7 +130,7 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 	context.Progress().Printf("Download queue: %d items (%s)\n", count, utils.HumanBytes(downloadSize))
 
 	// Download from the queue
-	context.Progress().InitBar(downloadSize, true)
+	context.Progress().InitBar(downloadSize, true, aptly.BarMirrorUpdateDownloadPackages)
 
 	downloadQueue := make(chan int)
 
@@ -219,7 +219,7 @@ func aptlyMirrorUpdate(cmd *commander.Command, args []string) error {
 	}
 
 	// Import downloaded files
-	context.Progress().InitBar(int64(len(queue)), false)
+	context.Progress().InitBar(int64(len(queue)), false, aptly.BarMirrorUpdateImportFiles)
 
 	for idx := range queue {
 

--- a/console/progress.go
+++ b/console/progress.go
@@ -69,7 +69,7 @@ func (p *Progress) Flush() {
 }
 
 // InitBar starts progressbar for count bytes or count items
-func (p *Progress) InitBar(count int64, isBytes bool) {
+func (p *Progress) InitBar(count int64, isBytes bool, barType aptly.BarType) {
 	if p.bar != nil {
 		panic("bar already initialized")
 	}

--- a/deb/index_files.go
+++ b/deb/index_files.go
@@ -263,7 +263,7 @@ func (files *indexFiles) ReleaseFile() *indexFile {
 
 func (files *indexFiles) FinalizeAll(progress aptly.Progress) (err error) {
 	if progress != nil {
-		progress.InitBar(int64(len(files.indexes)), false)
+		progress.InitBar(int64(len(files.indexes)), false, aptly.BarPublishFinalizeIndexes)
 		defer progress.ShutdownBar()
 	}
 

--- a/deb/list.go
+++ b/deb/list.go
@@ -99,7 +99,7 @@ func NewPackageListFromRefList(reflist *PackageRefList, collection *PackageColle
 	result := NewPackageListWithDuplicates(false, reflist.Len())
 
 	if progress != nil {
-		progress.InitBar(int64(reflist.Len()), false)
+		progress.InitBar(int64(reflist.Len()), false, aptly.BarGeneralBuildPackageList)
 	}
 
 	err := reflist.ForEach(func(key []byte) error {
@@ -301,7 +301,7 @@ func (l *PackageList) VerifyDependencies(options int, architectures []string, so
 	missing := make([]Dependency, 0, 128)
 
 	if progress != nil {
-		progress.InitBar(int64(l.Len())*int64(len(architectures)), false)
+		progress.InitBar(int64(l.Len())*int64(len(architectures)), false, aptly.BarGeneralVerifyDependencies)
 	}
 
 	for _, arch := range architectures {

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -557,16 +557,21 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 
 	indexes := newIndexFiles(publishedStorage, basePath, tempDir, suffix)
 
+	var count int64
+	for _, list := range lists {
+		count = count + int64(list.Len())
+	}
+
+	if progress != nil {
+		progress.InitBar(count, false)
+	}
+
 	for component, list := range lists {
 		hadUdebs := false
 
 		// For all architectures, pregenerate packages/sources files
 		for _, arch := range p.Architectures {
 			indexes.PackageIndex(component, arch, false)
-		}
-
-		if progress != nil {
-			progress.InitBar(int64(list.Len()), false)
 		}
 
 		list.PrepareIndex()
@@ -659,10 +664,6 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 			}
 		}
 
-		if progress != nil {
-			progress.ShutdownBar()
-		}
-
 		udebs := []bool{false}
 		if hadUdebs {
 			udebs = append(udebs, true)
@@ -698,6 +699,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 	}
 
 	if progress != nil {
+		progress.ShutdownBar()
 		progress.Printf("Finalizing metadata files...\n")
 	}
 

--- a/deb/publish.go
+++ b/deb/publish.go
@@ -563,7 +563,7 @@ func (p *PublishedRepo) Publish(packagePool aptly.PackagePool, publishedStorageP
 	}
 
 	if progress != nil {
-		progress.InitBar(count, false)
+		progress.InitBar(count, false, aptly.BarPublishGeneratePackageFiles)
 	}
 
 	for component, list := range lists {

--- a/deb/remote.go
+++ b/deb/remote.go
@@ -440,7 +440,7 @@ func (repo *RemoteRepo) DownloadPackageIndexes(progress aptly.Progress, d aptly.
 
 		if progress != nil {
 			stat, _ := packagesFile.Stat()
-			progress.InitBar(stat.Size(), true)
+			progress.InitBar(stat.Size(), true, aptly.BarMirrorUpdateBuildPackageList)
 		}
 
 		sreader := NewControlFileReader(packagesReader)
@@ -558,7 +558,7 @@ func (repo *RemoteRepo) FinalizeDownload(collectionFactory *CollectionFactory, p
 	repo.LastDownloadDate = time.Now()
 
 	if progress != nil {
-		progress.InitBar(int64(repo.packageList.Len()), true)
+		progress.InitBar(int64(repo.packageList.Len()), true, aptly.BarMirrorUpdateFinalizeDownload)
 	}
 
 	var i int

--- a/files/package_pool.go
+++ b/files/package_pool.go
@@ -94,7 +94,7 @@ func (pool *PackagePool) FilepathList(progress aptly.Progress) ([]string, error)
 	}
 
 	if progress != nil {
-		progress.InitBar(int64(len(dirs)), false)
+		progress.InitBar(int64(len(dirs)), false, aptly.BarGeneralBuildFileList)
 		defer progress.ShutdownBar()
 	}
 

--- a/http/temp.go
+++ b/http/temp.go
@@ -29,7 +29,7 @@ func DownloadTempWithChecksum(downloader aptly.Downloader, url string, expected 
 	tempfile := filepath.Join(tempdir, "buffer")
 
 	if expected != nil && downloader.GetProgress() != nil {
-		downloader.GetProgress().InitBar(expected.Size, true)
+		downloader.GetProgress().InitBar(expected.Size, true, aptly.BarMirrorUpdateDownloadIndexes)
 		defer downloader.GetProgress().ShutdownBar()
 	}
 

--- a/system/t12_api/publish.py
+++ b/system/t12_api/publish.py
@@ -135,6 +135,12 @@ class PublishSnapshotAPITest(APITest):
             }
         )
         self.check_equal(resp.json()['State'], 2)
+
+        _id = resp.json()['ID']
+        resp = self.get("/api/tasks/" + str(_id) + "/detail")
+        self.check_equal(resp.json()['RemainingNumberOfPackages'], 0)
+        self.check_equal(resp.json()['TotalNumberOfPackages'], 1)
+
         repo_expected = {
             'Architectures': ['i386'],
             'Distribution': 'squeeze',

--- a/task/output.go
+++ b/task/output.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"sync"
+
+	"github.com/smira/aptly/aptly"
 )
 
 // Output represents a safe standard output of task
@@ -11,6 +13,13 @@ import (
 type Output struct {
 	mu     *sync.Mutex
 	output *bytes.Buffer
+}
+
+// PublishOutput specific output for publishing api
+type PublishOutput struct {
+	*Output
+	PublishDetail
+	barType *aptly.BarType
 }
 
 // NewOutput creates new output
@@ -54,8 +63,18 @@ func (t *Output) Flush() {
 }
 
 // InitBar is needed for progress compatibility
-func (t *Output) InitBar(count int64, isBytes bool) {
+func (t *Output) InitBar(count int64, isBytes bool, barType aptly.BarType) {
 	// Not implemented
+}
+
+// InitBar publish output specific
+func (t *PublishOutput) InitBar(count int64, isBytes bool, barType aptly.BarType) {
+	t.barType = &barType
+	if barType == aptly.BarPublishGeneratePackageFiles {
+		t.TotalNumberOfPackages = count
+		t.RemainingNumberOfPackages = count
+		t.Store(t)
+	}
 }
 
 // ShutdownBar is needed for progress compatibility
@@ -63,9 +82,22 @@ func (t *Output) ShutdownBar() {
 	// Not implemented
 }
 
+// ShutdownBar publish output specific
+func (t *PublishOutput) ShutdownBar() {
+	t.barType = nil
+}
+
 // AddBar is needed for progress compatibility
 func (t *Output) AddBar(count int) {
 	// Not implemented
+}
+
+// AddBar publish output specific
+func (t *PublishOutput) AddBar(count int) {
+	if t.barType != nil && *t.barType == aptly.BarPublishGeneratePackageFiles {
+		t.RemainingNumberOfPackages--
+		t.Store(t)
+	}
 }
 
 // SetBar sets current position for progress bar

--- a/task/task.go
+++ b/task/task.go
@@ -12,6 +12,13 @@ type Detail struct {
 	atomic.Value
 }
 
+// PublishDetail represents publish task details
+type PublishDetail struct {
+	*Detail
+	TotalNumberOfPackages     int64
+	RemainingNumberOfPackages int64
+}
+
 // Process is a function implementing the actual task logic
 type Process func(out *Output, detail *Detail) error
 


### PR DESCRIPTION
For this to work following need to be adjusted:
* Progress interface expanded with name to be able to identify bar
* Combine generate index files and linking packages files into one progress bar
* Add publish specific output struct